### PR TITLE
Allow using native selects on initial load

### DIFF
--- a/ingeniousselect.js
+++ b/ingeniousselect.js
@@ -131,9 +131,7 @@
         };
 
         var useNativeSelect = function(selects) {
-            if (!$(selects[0]).parent().data('hasClickEvent')) {
-                return;
-            } else {
+            if ($(selects[0]).parent().data('hasClickEvent')) {
                 $(selects[0]).parent().data('hasClickEvent', false);
             }
 


### PR DESCRIPTION
The data-value "hasClickEvent" is first set when useIngeniousSelect() is called.
When the page is loaded with a width lower than the setting "minDeviceWidth" this
function would not be called the therefore the class "--useNative" could not be set initially.